### PR TITLE
Rework MyAnimeList token expiration and refreshing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -78,6 +78,8 @@ object PreferenceKeys {
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"
 
+    fun trachAuthExpired(syncId: Int) = "pref_tracker_auth_expired_$syncId"
+
     fun trackToken(syncId: Int) = "track_token_$syncId"
 
     const val sessionToken = "mangadex_session_token"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -154,7 +154,10 @@ class PreferencesHelper(val context: Context, val preferenceStore: PreferenceSto
     fun setTrackCredentials(sync: TrackService, username: String, password: String) {
         this.preferenceStore.getString(Keys.trackUsername(sync.id)).set(username)
         this.preferenceStore.getString(Keys.trackPassword(sync.id)).set(password)
+        this.preferenceStore.getBoolean(Keys.trackAuthExpired(sync.id), false).set(false)
     }
+
+    fun trackAuthExpired(sync: TrackService) = this.preferenceStore.getBoolean(Keys.trackAuthExpired(sync.id), false)
 
     fun trackToken(sync: TrackService) = this.preferenceStore.getString(Keys.trackToken(sync.id))
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -149,6 +149,14 @@ class MyAnimeList(private val context: Context, id: Int) : TrackService(id) {
         interceptor.setAuth(null)
     }
 
+    fun getIfAuthExpired(): Boolean {
+        return preferences.trackAuthExpired(this).get()
+    }
+
+    fun setAuthExpired() {
+        preferences.trackAuthExpired(this).set(true)
+    }
+
     fun saveOAuth(oAuth: OAuth?) {
         preferences.trackToken(this).set(json.encodeToString(oAuth))
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListInterceptor.kt
@@ -12,19 +12,20 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList, private var t
 
     private var oauth: OAuth? = null
     private val json: Json by injectLazy()
+    private val tokenExpired get() = myanimelist.getIfAuthExpired()
 
     override fun intercept(chain: Interceptor.Chain): Response {
+        if (tokenExpired) {
+            throw MALTokenExpired()
+        }
         val originalRequest = chain.request()
 
-        if (token.isNullOrEmpty()) {
-            throw IOException("Not authenticated with MyAnimeList")
+        if (oauth?.isExpired() == true) {
+            refreshToken(chain)
         }
+
         if (oauth == null) {
-            oauth = myanimelist.loadOAuth()
-        }
-        // Refresh access token if expired
-        if (oauth != null && oauth!!.isExpired()) {
-            setAuth(refreshToken(chain))
+            throw IOException("MAL: User is not authenticated")
         }
 
         // Add the authorization header to the original request
@@ -34,30 +35,8 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList, private var t
                 .addHeader("Authorization", "Bearer ${oauth!!.access_token}")
                 .build()
 
-        val response = chain.proceed(authRequest)
-        val tokenIsExpired =
-            response.headers["www-authenticate"]?.contains("The access token expired") ?: false
-
-        // Retry the request once with a new token in case it was not already refreshed
-        // by the is expired check before.
-        if (response.code == 401 && tokenIsExpired) {
-            response.close()
-
-            val newToken = refreshToken(chain)
-            setAuth(newToken)
-
-            val newRequest =
-                originalRequest
-                    .newBuilder()
-                    .addHeader("Authorization", "Bearer ${newToken.access_token}")
-                    .build()
-
-            return chain.proceed(newRequest)
-        }
-
-        return response
+        return chain.proceed(authRequest)
     }
-
     /**
      * Called when the user authenticates with MyAnimeList for the first time. Sets the refresh
      * token and the oauth object.
@@ -68,22 +47,37 @@ class MyAnimeListInterceptor(private val myanimelist: MyAnimeList, private var t
         myanimelist.saveOAuth(oauth)
     }
 
-    private fun refreshToken(chain: Interceptor.Chain): OAuth {
-        val newOauth = runCatching {
-            val oauthResponse = chain.proceed(MyAnimeListApi.refreshTokenRequest(oauth!!))
+    private fun refreshToken(chain: Interceptor.Chain): OAuth = synchronized(this) {
+        if (tokenExpired) throw MALTokenExpired()
+        oauth?.takeUnless { it.isExpired() }?.let { return@synchronized it }
 
-            if (oauthResponse.isSuccessful) {
-                with(json) { oauthResponse.parseAs<OAuth>() }
-            } else {
-                oauthResponse.close()
+        val response = try {
+            chain.proceed(MyAnimeListApi.refreshTokenRequest(oauth!!))
+        } catch (_: Throwable) {
+            throw MALTokenRefreshFailed()
+        }
+
+        if (response.code == 401) {
+            myanimelist.setAuthExpired()
+            throw MALTokenExpired()
+        }
+
+        return runCatching {
+            if (response.isSuccessful) {
+                with(json) { response.parseAs<OAuth>() }
+             } else {
+                response.close()
                 null
             }
         }
-
-        if (newOauth.getOrNull() == null) {
-            throw IOException("Failed to refresh the access token")
-        }
-
-        return newOauth.getOrNull()!!
+            .getOrNull()
+            ?.also {
+                this.oauth = it
+                myanimelist.saveOAuth(it)
+            }
+            ?: throw MALTokenRefreshFailed()
     }
 }
+
+class MALTokenRefreshFailed : IOException("MAL: Failed to refresh account token")
+class MALTokenExpired : IOException("MAL: Login has expired")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/OAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/OAuth.kt
@@ -10,6 +10,7 @@ data class OAuth(
     val created_at: Long = System.currentTimeMillis(),
     val expires_in: Long,
 ) {
-
-    fun isExpired() = System.currentTimeMillis() > created_at + (expires_in * 1000)
-}
+    // Assumes expired a minute earlier
+    private val adjustedExpiresIn: Long = (expires_in - 60) * 1000
+    fun isExpired() = created_at + adjustedExpiresIn < System.currentTimeMillis()
+}}


### PR DESCRIPTION
Partially fixes #1682. MAL syncing is still broken because they are blocking the endpoints at the moment, but this at least removes the error message spam in the meantime.

Credits to AntsyLich. Adapted from: https://github.com/mihonapp/mihon/commit/0f4de03d7a77b52490dc9a95e96a308b93b26e4f