### PR TITLE
Add Uploader to ChapterRow when No Group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 /build
 .idea/
+.kotlin/
 *iml
 *.iml
 */build

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -24,6 +24,8 @@ data class BackupChapter(
 
     // J2K specific values
     @ProtoNumber(800) var pagesLeft: Int = 0,
+    // Neko Values
+    @ProtoNumber(905) var uploader: String? = null,
 ) {
     fun toChapterImpl(): ChapterImpl {
         return ChapterImpl().apply {
@@ -31,6 +33,7 @@ data class BackupChapter(
             name = this@BackupChapter.name
             chapter_number = this@BackupChapter.chapterNumber
             scanlator = this@BackupChapter.scanlator
+            uploader = this@BackupChapter.uploader
             read = this@BackupChapter.read
             bookmark = this@BackupChapter.bookmark
             last_page_read = this@BackupChapter.lastPageRead
@@ -48,6 +51,7 @@ data class BackupChapter(
                 name = chapter.name,
                 chapterNumber = chapter.chapter_number,
                 scanlator = chapter.scanlator,
+                uploader = chapter.uploader,
                 read = chapter.read,
                 bookmark = chapter.bookmark,
                 lastPageRead = chapter.last_page_read,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
@@ -21,7 +21,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         const val DATABASE_NAME = "tachiyomi.db"
 
         /** Version of the database. */
-        const val DATABASE_VERSION = 39
+        const val DATABASE_VERSION = 38
     }
 
     override fun onOpen(db: SupportSQLiteDatabase) {
@@ -169,7 +169,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         if (oldVersion < 37) {
             db.execSQL(TrackTable.updateMangaUpdatesScore)
         }
-        if (oldVersion < 39) {
+        if (oldVersion < 38) {
             db.execSQL(ChapterTable.addUploader)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
@@ -21,7 +21,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         const val DATABASE_NAME = "tachiyomi.db"
 
         /** Version of the database. */
-        const val DATABASE_VERSION = 36
+        const val DATABASE_VERSION = 39
     }
 
     override fun onOpen(db: SupportSQLiteDatabase) {
@@ -168,6 +168,9 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         }
         if (oldVersion < 37) {
             db.execSQL(TrackTable.updateMangaUpdatesScore)
+        }
+        if (oldVersion < 39) {
+            db.execSQL(ChapterTable.addUploader)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/ChapterTypeMapping.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/ChapterTypeMapping.kt
@@ -29,6 +29,7 @@ import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_PAGES_LEFT
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_READ
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_SCANLATOR
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_SOURCE_ORDER
+import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_UPLOADER
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_URL
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.COL_VOL
 import eu.kanade.tachiyomi.data.database.tables.ChapterTable.TABLE
@@ -54,6 +55,7 @@ class ChapterPutResolver : DefaultPutResolver<Chapter>() {
             put(COL_VOL, obj.vol)
             put(COL_READ, obj.read)
             put(COL_SCANLATOR, obj.scanlator)
+            put(COL_UPLOADER, obj.uploader)
             put(COL_BOOKMARK, obj.bookmark)
             put(COL_DATE_FETCH, obj.date_fetch)
             put(COL_DATE_UPLOAD, obj.date_upload)
@@ -79,6 +81,7 @@ class ChapterGetResolver : DefaultGetResolver<Chapter>() {
             chapter_txt = cursor.getString(cursor.getColumnIndex(COL_CHP_TXT))
             chapter_title = cursor.getString(cursor.getColumnIndex(COL_CHP_TITLE))
             scanlator = cursor.getString(cursor.getColumnIndex(COL_SCANLATOR))
+            uploader = cursor.getString(cursor.getColumnIndex(COL_UPLOADER))
             read = cursor.getInt(cursor.getColumnIndex(COL_READ)) == 1
             bookmark = cursor.getInt(cursor.getColumnIndex(COL_BOOKMARK)) == 1
             date_fetch = cursor.getLong(cursor.getColumnIndex(COL_DATE_FETCH))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/ChapterImpl.kt
@@ -18,6 +18,8 @@ class ChapterImpl : Chapter {
 
     override var scanlator: String? = null
 
+    override var uploader: String? = null
+
     override var read: Boolean = false
 
     override var bookmark: Boolean = false

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
@@ -22,6 +22,8 @@ object ChapterTable {
 
     const val COL_SCANLATOR = "scanlator"
 
+    const val COL_UPLOADER = "uploader"
+
     const val COL_BOOKMARK = "bookmark"
 
     const val COL_DATE_FETCH = "date_fetch"
@@ -53,6 +55,7 @@ object ChapterTable {
             $COL_CHP_TITLE TEXT NOT NULL,
             $COL_VOL TEXT NOT NULL,
             $COL_SCANLATOR TEXT,
+            $COL_UPLOADER TEXT
             $COL_READ BOOLEAN NOT NULL,
             $COL_BOOKMARK BOOLEAN NOT NULL,
             $COL_LAST_PAGE_READ INT NOT NULL,
@@ -68,6 +71,7 @@ object ChapterTable {
             ON DELETE CASCADE
             )
             """
+
 
     val createMangaIdIndexQuery: String
         get() = "CREATE INDEX ${TABLE}_${COL_MANGA_ID}_index ON $TABLE($COL_MANGA_ID)"
@@ -97,4 +101,7 @@ object ChapterTable {
 
     val addLanguage: String
         get() = "ALTER TABLE $TABLE ADD COLUMN $COL_LANGUAGE TEXT DEFAULT ''"
+
+    val addUploader: String
+        get() = "ALTER TABLE $TABLE ADD COLUMN $COL_UPLOADER TEXT DEFAULT ''"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/ChapterTable.kt
@@ -55,7 +55,7 @@ object ChapterTable {
             $COL_CHP_TITLE TEXT NOT NULL,
             $COL_VOL TEXT NOT NULL,
             $COL_SCANLATOR TEXT,
-            $COL_UPLOADER TEXT
+            $COL_UPLOADER TEXT,
             $COL_READ BOOLEAN NOT NULL,
             $COL_BOOKMARK BOOLEAN NOT NULL,
             $COL_LAST_PAGE_READ INT NOT NULL,
@@ -71,7 +71,6 @@ object ChapterTable {
             ON DELETE CASCADE
             )
             """
-
 
     val createMangaIdIndexQuery: String
         get() = "CREATE INDEX ${TABLE}_${COL_MANGA_ID}_index ON $TABLE($COL_MANGA_ID)"

--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
@@ -115,7 +115,6 @@ interface MangaDexService {
     @GET(MdConstants.Api.group)
     suspend fun scanlatorGroup(@Query("name") scanlator: String): ApiResponse<GroupListDto>
 
-    @Headers("Cache-Control: no-cache")
     @GET("${MdConstants.Api.user}/{id}")
     suspend fun uploader(@Path("id") id: String): ApiResponse<UploaderDto>
 

--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.source.online.models.dto.MangaListDto
 import eu.kanade.tachiyomi.source.online.models.dto.RelationListDto
 import eu.kanade.tachiyomi.source.online.models.dto.RelationshipDtoList
 import eu.kanade.tachiyomi.source.online.models.dto.StatisticResponseDto
+import eu.kanade.tachiyomi.source.online.models.dto.UploaderDto
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.core.network.ProxyRetrofitQueryMap
 import retrofit2.http.Body
@@ -113,6 +114,10 @@ interface MangaDexService {
     @Headers("Cache-Control: no-cache")
     @GET(MdConstants.Api.group)
     suspend fun scanlatorGroup(@Query("name") scanlator: String): ApiResponse<GroupListDto>
+
+    @Headers("Cache-Control: no-cache")
+    @GET("${MdConstants.Api.user}/{id}")
+    suspend fun uploader(@Path("id") id: String): ApiResponse<UploaderDto>
 
     @GET("${MdConstants.Api.list}/{id}")
     suspend fun viewList(@Path("id") id: String): ApiResponse<ListDto>

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SChapter.kt
@@ -26,6 +26,8 @@ interface SChapter : Serializable {
 
     var scanlator: String?
 
+    var uploader: String?
+
     var language: String?
 
     // chapter id from mangadex
@@ -46,6 +48,7 @@ interface SChapter : Serializable {
         date_upload = other.date_upload
         chapter_number = other.chapter_number
         scanlator = other.scanlator
+        uploader = other.uploader
         mangadex_chapter_id = other.mangadex_chapter_id
         language = other.language
     }
@@ -57,6 +60,7 @@ interface SChapter : Serializable {
             date_upload = this@SChapter.date_upload
             chapter_number = this@SChapter.chapter_number
             scanlator = this@SChapter.scanlator
+            uploader = this@SChapter.uploader
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SChapterImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SChapterImpl.kt
@@ -18,6 +18,8 @@ class SChapterImpl : SChapter {
 
     override var scanlator: String? = null
 
+    override var uploader: String? = null
+
     override var language: String? = null
 
     override var mangadex_chapter_id: String = ""

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -185,8 +185,7 @@ class ApiMangaParser {
                 .map { uploaders[it.id] }
                 .firstOrNull()
 
-        if (scanlatorName.contains("no group") || scanlatorName.isEmpty()) {
-            scanlatorName.remove("no group")
+        if (scanlatorName.isEmpty()) {
             scanlatorName.add("No Group")
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -181,7 +181,6 @@ class ApiMangaParser {
 
         val uploaderName =
             networkChapter.relationships
-                .filter { it.id != MdConstants.uploaderBot }
                 .filter { it.type == MdConstants.Types.uploader }
                 .map { uploaders[it.id] }
                 .firstOrNull()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -141,12 +141,13 @@ class ApiMangaParser {
         lastChapterNumber: Int?,
         chapterListResponse: List<ChapterDataDto>,
         groupMap: Map<String, String>,
+        uploaderMap: Map<String, String>,
     ): Result<List<SChapter>, ResultError> {
         return runCatching {
                 Ok(
                     chapterListResponse
                         .asSequence()
-                        .map { mapChapter(it, lastChapterNumber, groupMap) }
+                        .map { mapChapter(it, lastChapterNumber, groupMap, uploaderMap) }
                         .toList()
                 )
             }
@@ -161,6 +162,7 @@ class ApiMangaParser {
         networkChapter: ChapterDataDto,
         lastChapterNumber: Int?,
         groups: Map<String, String>,
+        uploaders: Map<String, String>,
     ): SChapter {
         val chapter = SChapter.create()
         val attributes = networkChapter.attributes
@@ -176,6 +178,13 @@ class ApiMangaParser {
                 .filter { it.type == MdConstants.Types.scanlator }
                 .mapNotNull { groups[it.id] }
                 .toMutableSet()
+
+        val uploaderName =
+            networkChapter.relationships
+                .filter { it.id != MdConstants.uploaderBot }
+                .filter { it.type == MdConstants.Types.uploader }
+                .map { uploaders[it.id] }
+                .firstOrNull()
 
         if (scanlatorName.contains("no group") || scanlatorName.isEmpty()) {
             scanlatorName.remove("no group")

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/ApiMangaParser.kt
@@ -193,6 +193,8 @@ class ApiMangaParser {
 
         chapter.scanlator = MdUtil.cleanString(ChapterUtil.getScanlatorString(scanlatorName))
 
+        chapter.uploader = uploaderName ?: ""
+
         chapter.mangadex_chapter_id = MdUtil.getChapterUUID(chapter.url)
 
         chapter.language = attributes.translatedLanguage

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -186,7 +186,8 @@ class MangaHandler {
                 }
                 .andThen { results ->
                     val groupMap = getGroupMap(results)
-                    val uploaderMap = getUploaderMap(results)
+                    val uploaderMap = getUploaderMap(results, groupMap)
+
                     apiMangaParser.chapterListParse(
                         lastChapterNumber,
                         results,
@@ -237,11 +238,17 @@ class MangaHandler {
             .flatten()
             .filter { it.type == MdConstants.Types.scanlator }
             .associate { it.id to it.attributes!!.name!! }
+            .filterValues { it != "no group" }
     }
 
-    private suspend fun getUploaderMap(results: List<ChapterDataDto>): Map<String, String> {
+    private suspend fun getUploaderMap(
+        results: List<ChapterDataDto>,
+        groups: Map<String, String>,
+    ): Map<String, String> {
         return results
+            .asSequence()
             .map { chapter -> chapter.relationships }
+            .filter { relationships -> !relationships.any { groups.containsKey(it.id) } }
             .flatten()
             .filter { it.type == MdConstants.Types.uploader }
             .associate {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/ChapterDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/ChapterDto.kt
@@ -45,3 +45,9 @@ data class GroupListDto(
 @Serializable data class GroupDto(val id: String, val attributes: GroupAttributesDto)
 
 @Serializable data class GroupAttributesDto(val name: String, val description: String?)
+
+@Serializable data class UploaderDto(val result: String, val data: UserDto)
+
+@Serializable data class UserDto(val attributes: UserAttributesDto)
+
+@Serializable data class UserAttributesDto(val username: String)

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -81,6 +81,7 @@ fun syncChaptersWithSource(
                     downloadManager.renameChapter(manga, dbChapter, sourceChapter)
                 }
                 dbChapter.scanlator = sourceChapter.scanlator
+                dbChapter.uploader = sourceChapter.uploader
                 dbChapter.name = sourceChapter.name
                 dbChapter.vol = sourceChapter.vol
                 dbChapter.chapter_txt = sourceChapter.chapter_txt
@@ -222,6 +223,7 @@ fun syncChaptersWithSource(
 // checks if the chapter in db needs updated
 private fun shouldUpdateDbChapter(dbChapter: Chapter, sourceChapter: Chapter): Boolean {
     return dbChapter.scanlator != sourceChapter.scanlator ||
+        dbChapter.uploader != sourceChapter.uploader ||
         dbChapter.name != sourceChapter.name ||
         dbChapter.date_upload != sourceChapter.date_upload ||
         dbChapter.chapter_number != sourceChapter.chapter_number ||

--- a/app/src/main/java/org/nekomanga/domain/chapter/Chapter.kt
+++ b/app/src/main/java/org/nekomanga/domain/chapter/Chapter.kt
@@ -30,6 +30,7 @@ data class SimpleChapter(
     val mangaDexChapterId: String,
     val oldMangaDexChapterId: String?,
     val scanlator: String,
+    val uploader: String,
     val lastRead: Long = 0L,
 ) {
     val isRecognizedNumber = chapterNumber >= 0f
@@ -68,6 +69,7 @@ data class SimpleChapter(
             it.mangadex_chapter_id = mangaDexChapterId
             it.old_mangadex_id = oldMangaDexChapterId
             it.language = language
+            it.uploader = uploader
         }
     }
 
@@ -78,6 +80,7 @@ data class SimpleChapter(
             dateUpload = sChapter.date_upload,
             chapterNumber = sChapter.chapter_number,
             scanlator = sChapter.scanlator ?: "",
+            uploader = sChapter.uploader ?: "",
             volume = sChapter.vol,
         )
     }
@@ -101,6 +104,7 @@ data class SimpleChapter(
                 chapterTitle = "",
                 volume = "",
                 scanlator = "",
+                uploader = "",
                 mangaDexChapterId = "",
                 oldMangaDexChapterId = null,
                 language = "",
@@ -114,6 +118,7 @@ data class SimpleChapter(
             it.url = url
             it.name = name
             it.scanlator = scanlator
+            it.uploader = uploader
             it.read = read
             it.bookmark = bookmark
             it.last_page_read = lastPageRead
@@ -157,6 +162,7 @@ fun Chapter.toSimpleChapter(lastRead: Long = 0L): SimpleChapter? {
         dateUpload = date_upload,
         chapterNumber = chapter_number,
         scanlator = scanlator ?: "",
+        uploader = uploader ?: "",
         volume = vol,
         chapterTitle = chapter_title,
         chapterText = chapter_txt,

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -69,6 +69,7 @@ fun ChapterRow(
     themeColor: ThemeColorState,
     title: String,
     scanlator: String,
+    uploader: String,
     language: String?,
     chapterNumber: Double,
     dateUploaded: Long,
@@ -161,6 +162,7 @@ fun ChapterRow(
                 markPrevious = markPrevious,
                 isMerged = isMerged,
                 blockScanlator = blockScanlator,
+                uploader = uploader,
             )
         }
     }
@@ -187,6 +189,7 @@ private fun ChapterInfo(
     shouldHideChapterTitles: Boolean,
     title: String,
     scanlator: String,
+    uploader: String,
     language: String?,
     chapterNumber: Double,
     dateUploaded: Long,
@@ -320,6 +323,10 @@ private fun ChapterInfo(
 
             if (scanlator.isNotBlank()) {
                 statuses.add(scanlator)
+            }
+
+            if (uploader.isNotBlank()) {
+                statuses.add(uploader)
             }
 
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
+++ b/app/src/main/java/org/nekomanga/presentation/components/ChapterRow.kt
@@ -322,11 +322,10 @@ private fun ChapterInfo(
             }
 
             if (scanlator.isNotBlank()) {
+                if (scanlator == "No Group") {
+                    statuses.add(uploader)
+                }
                 statuses.add(scanlator)
-            }
-
-            if (uploader.isNotBlank()) {
-                statuses.add(uploader)
             }
 
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/MangaScreen.kt
@@ -458,6 +458,7 @@ private fun ChapterRow(
         themeColor = themeColorState,
         title = chapterItem.chapter.name,
         scanlator = chapterItem.chapter.scanlator,
+        uploader = chapterItem.chapter.uploader,
         language = chapterItem.chapter.language,
         chapterNumber = chapterItem.chapter.chapterNumber.toDouble(),
         dateUploaded = chapterItem.chapter.dateUpload,

--- a/app/src/test/java/eu/kanade/tachiyomi/util/ChapterExtensionsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/ChapterExtensionsTest.kt
@@ -36,6 +36,7 @@ class ChapterExtensionsTest {
                     mangaDexChapterId = "",
                     oldMangaDexChapterId = null,
                     scanlator = "",
+                    uploader = "",
                 )
         )
     }

--- a/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
+++ b/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
@@ -9,6 +9,7 @@ object MdConstants {
     const val currentSeasonalId = "328b04cf-aad6-4e2d-b3fc-4694075b8437"
     const val staffPicksId = "805ba886-dd99-4aa4-b460-4bd7c7b71352"
     const val nekoDevPicksId = "9650e839-1266-4456-860d-c7eee164b451"
+    const val uploaderBot = "e29214b2-9bd4-4e01-9c65-c75b3b0c95ef"
     const val name = "MangaDex"
     const val baseUrl = "https://mangadex.org"
     const val cdnUrl = "https://uploads.mangadex.org"
@@ -27,6 +28,7 @@ object MdConstants {
         const val chapter = "/chapter"
         const val cover = "/cover"
         const val group = "/group"
+        const val user = "/user"
         const val author = "/author"
         const val userFollows = "/user/follows/manga"
         const val readingStatusForAllManga = "/manga/status"
@@ -98,6 +100,7 @@ object MdConstants {
         const val coverArt = "cover_art"
         const val manga = "manga"
         const val scanlator = "scanlation_group"
+        const val uploader = "user"
     }
 
     object ContentRating {

--- a/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
+++ b/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
@@ -9,7 +9,6 @@ object MdConstants {
     const val currentSeasonalId = "328b04cf-aad6-4e2d-b3fc-4694075b8437"
     const val staffPicksId = "805ba886-dd99-4aa4-b460-4bd7c7b71352"
     const val nekoDevPicksId = "9650e839-1266-4456-860d-c7eee164b451"
-    const val uploaderBot = "e29214b2-9bd4-4e01-9c65-c75b3b0c95ef"
     const val name = "MangaDex"
     const val baseUrl = "https://mangadex.org"
     const val cdnUrl = "https://uploads.mangadex.org"


### PR DESCRIPTION
Currently there is no way for an user to differentiate between multiple chapters with `No Group`.

This PR adds an uploader field to the view:

![image](https://github.com/user-attachments/assets/7158f626-e9f7-4d64-bac4-7c3c86417b52)
