### PR TITLE
fix: dedup uploader requests

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/handlers/MangaHandler.kt
@@ -251,6 +251,7 @@ class MangaHandler {
             .filter { relationships -> !relationships.any { groups.containsKey(it.id) } }
             .flatten()
             .filter { it.type == MdConstants.Types.uploader }
+            .distinctBy { it.id }
             .associate {
                 it.id to
                     service


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed duplicate uploader requests by adding a distinctBy filter, preventing excessive API calls for certain manga titles (previously causing redundant requests for some titles).

<!-- End of auto-generated description by mrge. -->

This is something I didn't notice when I made #2067, it is spamming requests for certain titles, (~900 times for [Neko-Oji](https://mangadex.org/title/642bf922-094b-4a98-b0b7-8d6add31b729), for instance):

![Screenshot_2025-04-17_22-06-23](https://github.com/user-attachments/assets/9b7ea959-7ed9-432d-ae6a-3ed03d7124f3)
