### PR TITLE
fix: remove unavailable chapters from download queue

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -108,6 +108,7 @@ class Downloader(
             return false
         }
 
+        queueState.value.apply { removeFromQueueIf { it.chapterItem.isUnavailable } }
         val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
         pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -170,8 +170,12 @@ class Downloader(
                                 val activeDownloads =
                                     queue
                                         .asSequence()
+                                        .apply {
+                                            removeFromQueueIf { it.chapterItem.isUnavailable }
+                                        }
                                         .filter {
-                                            it.status.value <= Download.State.DOWNLOADING.value
+                                            it.status.value <= Download.State.DOWNLOADING.value &&
+                                                !it.chapterItem.isUnavailable
                                         } // Ignore completed downloads, leave them in the queue
                                         .groupBy { it.source }
                                         .toList()


### PR DESCRIPTION
Solves the crash for people with large libraries that have enabled autodownload new chapters