### PR TITLE
fix: catch exception for updating status when merge server is unavailable

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/komga/Komga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/komga/Komga.kt
@@ -211,7 +211,11 @@ class Komga : MergedServerSource() {
             val chapterUrl = "${hostUrl()}${chapter.url}/read-progress"
             val body =
                 "{\"completed\":${read},\"page\":0}".toRequestBody("application/json".toMediaType())
-            customClient().newCall(PATCH(chapterUrl, headers, body)).await()
+            try {
+                customClient().newCall(PATCH(chapterUrl, headers, body)).await()
+            } catch (e: Exception) {
+                TimberKt.w(e) { "error updating chapter status in komga" }
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
@@ -295,9 +295,13 @@ class Suwayomi : MergedServerSource() {
         val apiUrl = "${hostUrl()}/api/graphql".toHttpUrl().newBuilder().toString()
 
         val chapterIds = chapters.map { it.url.split(" ", limit = 2)[1].toLong() }
-        customClient()
-            .newCall(POST(apiUrl, headers, updateChapterFormBuilder(chapterIds, read)))
-            .await()
+        try {
+            customClient()
+                .newCall(POST(apiUrl, headers, updateChapterFormBuilder(chapterIds, read)))
+                .await()
+        } catch (e: Exception) {
+            TimberKt.w(e) { "error updating chapter status in suwayomi" }
+        }
     }
 
     fun updateChapterFormBuilder(chapterIds: List<Long>, read: Boolean): RequestBody {


### PR DESCRIPTION
Fixes crash after marking as read/unread when self-hosted server is unavailable