### PR TITLE
fix: suwayomi and null volume sorting

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -62,10 +62,9 @@ fun syncChaptersWithSource(
                         downloadManager.downloadedChapterName(dbChapter).firstOrNull {
                             it in allDownloadsMap
                         }
-                    if(validName != null) {
+                    if (validName != null) {
                         allDownloadsMap.remove(validName)
                     }
-
                 } else if (dbChapter.isLocalSource()) { // means its not downloaded currently
                     db.deleteChapter(dbChapter).executeAsBlocking()
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -5,7 +5,9 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.isLocalSource
 import eu.kanade.tachiyomi.source.model.isMergedChapter
 import eu.kanade.tachiyomi.source.online.utils.MdLang
+import eu.kanade.tachiyomi.util.system.toInt
 import kotlin.math.floor
+import org.nekomanga.logging.TimberKt
 
 /** This attempts to create a smart source order used when a manga is merged */
 fun reorderChapters(sourceChapters: List<SChapter>, manga: Manga): List<SChapter> {
@@ -13,21 +15,48 @@ fun reorderChapters(sourceChapters: List<SChapter>, manga: Manga): List<SChapter
         return sourceChapters
     }
 
+    var (withVolume, nullVolume) = sourceChapters.partition { getVolumeNum(it) == null }
+    nullVolume = nullVolume.sortedWith(compareBy { getChapterNum(it) })
+
     // mangalife tends to not include a volume number for manga
     val sorter =
         if (manga.lang_flag != null && MdLang.fromIsoCode(manga.lang_flag!!) == MdLang.JAPANESE) {
-            compareByDescending<SChapter> { getChapterNum(it) == null }
-                .thenByDescending { getChapterNum(it) }
+            compareBy<SChapter> { getChapterNum(it) == null }.thenBy { getChapterNum(it) }
         } else {
-            compareByDescending<SChapter> { getVolumeNum(it) == null }
-                .thenByDescending { getVolumeNum(it) }
-                .thenByDescending { getChapterNum(it) }
+            compareBy<SChapter> { getVolumeNum(it) }.thenBy { getChapterNum(it) }
         }
+    withVolume = withVolume.sortedWith(sorter)
 
-    return sourceChapters.sortedWith(sorter)
+    return listOf(withVolume.asSequence(), nullVolume.asSequence())
+        .mergeSorted(compareBy<SChapter> { getChapterNum(it) == null }.thenBy { getChapterNum(it) })
+        .toList()
+        .reversed()
+}
+
+fun <T> List<Sequence<T>>.mergeSorted(comparator: Comparator<T>): Sequence<T> {
+    val iteratorToCurrentValues =
+        map { it.iterator() }.filter { it.hasNext() }.associateWith { it.next() }.toMutableMap()
+
+    val c: Comparator<Map.Entry<Iterator<T>, T>> = Comparator.comparing({ it.value }, comparator)
+
+    return sequence {
+        while (iteratorToCurrentValues.isNotEmpty()) {
+            val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
+
+            yield(smallestEntry.value)
+
+            if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
+            else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
+        }
+    }
 }
 
 fun getChapterNum(chapter: SChapter): Float? {
+    TimberKt.d {
+        "${getVolumeNum(chapter)} ${chapter.chapter_txt} ${
+            chapter.isMergedChapter().toInt()
+        } ${chapter.name} "
+    }
     return when (chapter.name.contains("oneshot", true) && !chapter.isMergedChapter()) {
         true -> 0f
         false -> {


### PR DESCRIPTION
Sanitize `vol`, `chapter_txt` and `chapter_title` for suwayomi.

Improve the source order sorting for chapters with null volume. This is done by partitioning the lists, sorting them separately and merging the lists keeping the previously sorted chapter order:

![image](https://github.com/user-attachments/assets/2039f519-32ba-4941-b8df-2fcf562edf92)




