### PR TITLE
feat: improve ordering of null volume chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -4,7 +4,6 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.isLocalSource
 import eu.kanade.tachiyomi.source.model.isMergedChapter
-import eu.kanade.tachiyomi.util.system.toInt
 import kotlin.math.floor
 
 /** This attempts to create a smart source order used when a manga is merged */

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -4,7 +4,7 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.isLocalSource
 import eu.kanade.tachiyomi.source.model.isMergedChapter
-import eu.kanade.tachiyomi.source.online.utils.MdLang
+import eu.kanade.tachiyomi.util.system.toInt
 import kotlin.math.floor
 
 /** This attempts to create a smart source order used when a manga is merged */
@@ -14,17 +14,44 @@ fun reorderChapters(sourceChapters: List<SChapter>, manga: Manga): List<SChapter
     }
 
     // mangalife tends to not include a volume number for manga
-    val sorter =
-        if (manga.lang_flag != null && MdLang.fromIsoCode(manga.lang_flag!!) == MdLang.JAPANESE) {
-            compareByDescending<SChapter> { getChapterNum(it) == null }
+    var (nullVolume, withVolume) = sourceChapters.partition { getVolumeNum(it) == null }
+    nullVolume = nullVolume.sortedWith(compareByDescending { getChapterNum(it) })
+    withVolume =
+        withVolume.sortedWith(
+            compareByDescending<SChapter> { getVolumeNum(it) }
+                .thenByDescending { getChapterNum(it) == null }
                 .thenByDescending { getChapterNum(it) }
-        } else {
-            compareByDescending<SChapter> { getVolumeNum(it) == null }
-                .thenByDescending { getVolumeNum(it) }
-                .thenByDescending { getChapterNum(it) }
-        }
+        )
 
-    return sourceChapters.sortedWith(sorter)
+    return listOf(nullVolume, withVolume).mergeSorted()
+}
+
+// Adapted from https://stackoverflow.com/a/69041133
+private fun List<List<SChapter>>.mergeSorted(): List<SChapter> {
+    val iteratorToCurrentValues =
+        map { it.reversed().iterator() }
+            .filter { it.hasNext() }
+            .associateWith { it.next() }
+            .toMutableMap()
+
+    val c: Comparator<Map.Entry<Iterator<SChapter>, SChapter>> =
+        Comparator.comparing(
+            { it.value },
+            compareBy<SChapter> { getChapterNum(it) == null }.thenBy { getChapterNum(it) },
+        )
+
+    return sequence {
+        while (iteratorToCurrentValues.isNotEmpty()) {
+            val smallestEntry = iteratorToCurrentValues.minWithOrNull(c)!!
+
+            yield(smallestEntry.value)
+
+            if (!smallestEntry.key.hasNext()) iteratorToCurrentValues.remove(smallestEntry.key)
+            else iteratorToCurrentValues[smallestEntry.key] = smallestEntry.key.next()
+        }
+    }
+        .toList()
+        .reversed()
 }
 
 fun getChapterNum(chapter: SChapter): Float? {
@@ -32,14 +59,14 @@ fun getChapterNum(chapter: SChapter): Float? {
         true -> 0f
         false -> {
             val txt = chapter.chapter_txt
-            txt.subStringfloatOrNull("Ch.")
-                ?: txt.subStringfloatOrNull("Chp.")
-                ?: txt.subStringfloatOrNull("Chapter")
+            txt.subStringFloatOrNull("Ch.")
+                ?: txt.subStringFloatOrNull("Chp.")
+                ?: txt.subStringFloatOrNull("Chapter")
         }
     }
 }
 
-private fun String.subStringfloatOrNull(delimiter: String): Float? {
+private fun String.subStringFloatOrNull(delimiter: String): Float? {
     return this.substringAfter(delimiter).toFloatOrNull()
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/SourceChapterSorter.kt
@@ -14,7 +14,11 @@ fun reorderChapters(sourceChapters: List<SChapter>, manga: Manga): List<SChapter
 
     // mangalife tends to not include a volume number for manga
     var (nullVolume, withVolume) = sourceChapters.partition { getVolumeNum(it) == null }
-    nullVolume = nullVolume.sortedWith(compareByDescending { getChapterNum(it) })
+    nullVolume =
+        nullVolume.sortedWith(
+            compareByDescending<SChapter> { getChapterNum(it) == null }
+                .thenByDescending { getChapterNum(it) },
+        )
     withVolume =
         withVolume.sortedWith(
             compareByDescending<SChapter> { getVolumeNum(it) }


### PR DESCRIPTION
Improve the source order sorting for chapters with null volume. This is done by partitioning the lists, sorting them separately and merging the lists keeping the previously sorted chapter order:

![image](https://github.com/user-attachments/assets/2039f519-32ba-4941-b8df-2fcf562edf92)

This new behavior also should end up being better for when the volumes reset the chapter numbering, since it'll be a best attempt at aligning the chapters without volume instead of just separating them:

![image](https://github.com/user-attachments/assets/d05a56a7-653b-4724-a0a0-e60b3d7f3cd5)


