### PR TITLE
fix: webtoon frame memory leak

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -359,6 +359,7 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
         super.onDestroy()
         viewModel.deletePendingChapters()
         viewer?.destroy()
+        binding.viewerContainer.removeAllViews()
         binding.chaptersSheet.chaptersBottomSheet.adapter = null
         viewer = null
         config = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -163,6 +163,10 @@ class WebtoonViewer(val activity: ReaderActivity, val hasMargins: Boolean = fals
         super.destroy()
         scope.cancel()
         subscriptions.unsubscribe()
+
+        // Clear activity references
+        recycler.adapter = null
+        frame.removeAllViews()
     }
 
     /**


### PR DESCRIPTION
This is an attempt at fixing the webtoon reader memory leak when the app is suspended. This happens because the activity is destroyed but the view containing a reference to it isn't:

```
┬───
│ GC Root: Thread object
│
├─ kotlinx.coroutines.scheduling.CoroutineScheduler$Worker instance
│    Leaking: UNKNOWN
│    Retaining 7.2 MB in 22996 objects
│    Thread name: 'DefaultDispatcher-worker-14'
│    ↓ CoroutineScheduler$Worker<Java Local>
│                               ~~~~~~~~~~~~
├─ eu.kanade.tachiyomi.ui.reader.loader.HttpPageLoader instance
│    Leaking: UNKNOWN
│    Retaining 88 B in 4 objects
│    ↓ HttpPageLoader.chapter
│                     ~~~~~~~
├─ eu.kanade.tachiyomi.ui.reader.model.ReaderChapter instance
│    Leaking: UNKNOWN
│    Retaining 7.2 MB in 22757 objects
│    ↓ ReaderChapter.state
│                    ~~~~~
├─ eu.kanade.tachiyomi.ui.reader.model.ReaderChapter$State$Loaded instance
│    Leaking: UNKNOWN
│    Retaining 7.2 MB in 22743 objects
│    ↓ ReaderChapter$State$Loaded.pages
│                                 ~~~~~
├─ java.util.ArrayList instance
│    Leaking: UNKNOWN
│    Retaining 7.2 MB in 22742 objects
│    ↓ ArrayList[3]
│               ~~~
├─ eu.kanade.tachiyomi.ui.reader.model.ReaderPage instance
│    Leaking: UNKNOWN
│    Retaining 7.9 kB in 177 objects
│    ↓ Page._statusFlow
│           ~~~~~~~~~~~
├─ kotlinx.coroutines.flow.StateFlowImpl instance
│    Leaking: UNKNOWN
│    Retaining 7.7 kB in 171 objects
│    ↓ AbstractSharedFlow.slots
│                         ~~~~~
├─ kotlinx.coroutines.flow.StateFlowSlot[] array
│    Leaking: UNKNOWN
│    Retaining 7.6 kB in 170 objects
│    ↓ StateFlowSlot[0]
│                   ~~~
├─ kotlinx.coroutines.flow.StateFlowSlot instance
│    Leaking: UNKNOWN
│    Retaining 7.6 kB in 169 objects
│    ↓ StateFlowSlot._state
│                    ~~~~~~
├─ java.util.concurrent.atomic.AtomicReference instance
│    Leaking: UNKNOWN
│    Retaining 7.6 kB in 168 objects
│    ↓ AtomicReference.value
│                      ~~~~~
├─ kotlinx.coroutines.CancellableContinuationImpl instance
│    Leaking: UNKNOWN
│    Retaining 7.6 kB in 167 objects
│    ↓ CancellableContinuationImpl._parentHandle$volatile
│                                  ~~~~~~~~~~~~~~~~~~~~~~
├─ kotlinx.coroutines.ChildContinuation instance
│    Leaking: UNKNOWN
│    Retaining 28 B in 1 objects
│    ↓ JobNode.job
│              ~~~
├─ kotlinx.coroutines.internal.ScopeCoroutine instance
│    Leaking: UNKNOWN
│    Retaining 148 B in 5 objects
│    ↓ ScopeCoroutine.uCont
│                     ~~~~~
├─ kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1 instance
│    Leaking: UNKNOWN
│    Retaining 80 B in 2 objects
│    Anonymous subclass of kotlin.coroutines.jvm.internal.SuspendLambda
│    ↓ ChannelFlow$collectToFun$1.this$0
│                                 ~~~~~~
├─ kotlinx.coroutines.flow.internal.ChannelFlowTransformLatest instance
│    Leaking: UNKNOWN
│    Retaining 104 B in 3 objects
│    ↓ ChannelFlowTransformLatest.transform
│                                 ~~~~~~~~~
├─ kotlinx.coroutines.flow.FlowKt__MergeKt$mapLatest$1 instance
│    Leaking: UNKNOWN
│    Retaining 76 B in 2 objects
│    Anonymous subclass of kotlin.coroutines.jvm.internal.SuspendLambda
│    ↓ FlowKt__MergeKt$mapLatest$1.$transform
│                                  ~~~~~~~~~~
├─ eu.kanade.tachiyomi.ui.reader.viewer.webtoon.
│  WebtoonPageHolder$launchLoadJob$2$1 instance
│    Leaking: UNKNOWN
│    Retaining 36 B in 1 objects
│    Anonymous subclass of kotlin.coroutines.jvm.internal.SuspendLambda
│    ↓ WebtoonPageHolder$launchLoadJob$2$1.this$0
│                                          ~~~~~~
├─ eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonPageHolder instance
│    Leaking: UNKNOWN
│    Retaining 5.5 kB in 101 objects
│    ↓ WebtoonPageHolder.frame
│                        ~~~~~
├─ eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView instance
│    Leaking: YES (View.mContext references a destroyed activity)
│    Retaining 2.1 MB in 98 objects
│    View is part of a window view hierarchy
│    View.mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    mContext instance of eu.kanade.tachiyomi.ui.reader.ReaderActivity with
│    mDestroyed = true
│    ↓ View.mContext
╰→ eu.kanade.tachiyomi.ui.reader.ReaderActivity instance
​     Leaking: YES (ObjectWatcher was watching this because eu.kanade.tachiyomi.
​     ui.reader.ReaderActivity received Activity#onDestroy() callback and
​     Activity#mDestroyed is true)
​     Retaining 125.4 kB in 3269 objects
​     key = de4b238b-1a0e-4c7c-b00c-cd54e53e0da3
​     watchDurationMillis = 9801
​     retainedDurationMillis = 4791
​     mApplication instance of org.nekomanga.App
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper

METADATA

Build.VERSION.SDK_INT: 35
Build.MANUFACTURER: Google
LeakCanary version: 2.14
App process name: org.nekomanga.neko.debug
Class count: 41801
Instance count: 633134
Primitive array count: 309600
Object array count: 80417
Thread count: 60
Heap total bytes: 59924736
Bitmap count: 83
Bitmap total bytes: 57729284
Large bitmap count: 0
Large bitmap total bytes: 0
Db 1: open /data/user/0/org.nekomanga.neko.debug/no_backup/androidx.work.workdb
Db 2: open /data/user/0/org.nekomanga.neko.debug/databases/leaks.db
Stats: LruCache[maxSize=3000,hits=185705,misses=361756,hitRate=33%]
RandomAccess[bytes=18859692,reads=361756,travel=310865683854,range=71922000,size
=87773465]
Analysis duration: 12644 ms
```

