### PR TITLE
feat: more options for auto adding to MD library

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -109,6 +109,7 @@ object PreferenceKeys {
     const val enablePort443Only = "use_port_443_only_for_image_server"
 
     const val addToLibraryAsPlannedToRead = "add_to_libray_as_planned_to_read"
+    const val autoAddToMangadexLibrary = "auto_add_to_mangadex_library"
 
     const val mangadexSyncToLibraryIndexes = "pref_mangadex_sync_to_library_indexes"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.data.updater.AppDownloadInstallJob
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.ui.feed.FeedHistoryGroup
 import eu.kanade.tachiyomi.ui.feed.FeedScreenType
+import eu.kanade.tachiyomi.util.system.toInt
 import java.security.SecureRandom
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -229,8 +230,15 @@ class PreferencesHelper(val context: Context, val preferenceStore: PreferenceSto
     fun showContentRatingFilter() =
         this.preferenceStore.getBoolean(Keys.showContentRatingFilter, true)
 
+    // Remove after a few releases
     fun addToLibraryAsPlannedToRead() =
         this.preferenceStore.getBoolean(Keys.addToLibraryAsPlannedToRead, false)
+
+    fun autoAddToMangadexLibrary() =
+        this.preferenceStore.getInt(
+            Keys.autoAddToMangadexLibrary,
+            addToLibraryAsPlannedToRead().get().toInt(),
+        )
 
     fun contentRatingSelections() =
         this.preferenceStore.getStringSet(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailPresenter.kt
@@ -919,12 +919,19 @@ class MangaDetailPresenter(
                             }
                             db.insertTrack(track).executeOnIO()
                         }
+                        val autoAddStatus = preferences.autoAddToMangadexLibrary().get()
                         val shouldAddAsPlanToRead =
                             currentManga().favorite &&
-                                preferences.addToLibraryAsPlannedToRead().get() &&
+                                autoAddStatus in 1..3 &&
                                 FollowStatus.isUnfollowed(track.status)
                         if (shouldAddAsPlanToRead && isOnline()) {
-                            track.status = FollowStatus.PLAN_TO_READ.int
+                            track.status =
+                                when (autoAddStatus) {
+                                    1 -> FollowStatus.PLAN_TO_READ.int
+                                    3 -> FollowStatus.READING.int
+                                    2 -> FollowStatus.ON_HOLD.int
+                                    else -> track.status // Unreachable
+                                }
                             trackingCoordinator.updateTrackingService(
                                 track.toTrackItem(),
                                 trackManager.mdList.toTrackServiceItem(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSiteController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsSiteController.kt
@@ -254,11 +254,45 @@ class SettingsSiteController : SettingsController(), MangadexLogoutDialog.Listen
                 onClick { StatusSyncJob.startNow(context, StatusSyncJob.entireLibraryToDex) }
             }
 
-            switchPreference {
-                key = PreferenceKeys.addToLibraryAsPlannedToRead
-                titleRes = R.string.add_favorites_as_planned_to_read
-                summaryRes = R.string.add_favorites_as_planned_to_read_summary
-                defaultValue = false
+            intListPreference(activity) {
+                key = PreferenceKeys.autoAddToMangadexLibrary
+                titleRes = R.string.auto_add_to_mangadex_library
+                summaryRes =
+                    when (preferences.autoAddToMangadexLibrary().get()) {
+                        1 -> R.string.follows_plan_to_read
+                        2 -> R.string.follows_on_hold
+                        3 -> R.string.follows_reading
+                        else -> R.string.disabled
+                    }
+                entriesRes =
+                    arrayOf(
+                        R.string.disabled,
+                        R.string.follows_plan_to_read,
+                        R.string.follows_on_hold,
+                        R.string.follows_reading,
+                    )
+                entryValues = (0..3).toList()
+                defaultValue = 0
+                customSelectedValue =
+                    when (val value = preferences.autoAddToMangadexLibrary().get()) {
+                        in 0..3 -> value
+                        else -> 0
+                    }
+                onChange { newValue ->
+                    summaryRes =
+                        when (preferences.autoAddToMangadexLibrary().get()) {
+                            1 -> R.string.follows_plan_to_read
+                            2 -> R.string.follows_on_hold
+                            3 -> R.string.follows_reading
+                            else -> R.string.disabled
+                        }
+                    customSelectedValue =
+                        when (newValue) {
+                            in 0..3 -> newValue as Int
+                            else -> 0
+                        }
+                    true
+                }
             }
         }
 

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -1469,8 +1469,7 @@
     <string name="use_port_443_title">Use Image Servers with Port 443 only</string>
     <string name="use_port_443_summary">"Enable to only request image servers that use port 443. This allows users with stricter firewall restrictions to access MangaDex images"</string>
 
-    <string name="add_favorites_as_planned_to_read">Add to library as planned to read</string>
-    <string name="add_favorites_as_planned_to_read_summary">When enabled manga added to your library will be updated with Plan To Read Status on MangaDex</string>
+    <string name="auto_add_to_mangadex_library">Add to MangaDex library with status</string>
     <string name="use_cache_source">Use cached source</string>
     <string name="use_cache_source_summary">Recommended to not use at this time, this was a legacy feature for V3 of MangaDex</string>
 


### PR DESCRIPTION
Defaults to disabled. If `Add to library as planned to read` was previously enabled, it uses that value instead.

<img width="539" height="397" alt="image" src="https://github.com/user-attachments/assets/ee358f35-b2d7-4960-90cf-0c8e9a499c52" />
