### PR TITLE
feat: dynamic seasonal list

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/services/MangaDexService.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.online.models.dto.MangaDto
 import eu.kanade.tachiyomi.source.online.models.dto.MangaListDto
 import eu.kanade.tachiyomi.source.online.models.dto.RelationListDto
 import eu.kanade.tachiyomi.source.online.models.dto.RelationshipDtoList
+import eu.kanade.tachiyomi.source.online.models.dto.SeasonalDto
 import eu.kanade.tachiyomi.source.online.models.dto.StatisticResponseDto
 import eu.kanade.tachiyomi.source.online.models.dto.UploaderDto
 import org.nekomanga.constants.MdConstants
@@ -122,4 +123,6 @@ interface MangaDexService {
 
     @POST(MdConstants.atHomeReportUrl)
     suspend fun atHomeImageReport(@Body atHomeImageReportDto: AtHomeImageReportDto)
+
+    @GET(MdConstants.seasonalApi) suspend fun getSeasonalList(): ApiResponse<SeasonalDto>
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/MangaDex.kt
@@ -5,6 +5,8 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.andThen
 import com.github.michaelbull.result.coroutines.coroutineBinding
+import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.mapSuccess
 import eu.kanade.tachiyomi.data.database.models.Scanlator
 import eu.kanade.tachiyomi.data.database.models.SourceArtwork
 import eu.kanade.tachiyomi.data.database.models.Track
@@ -148,7 +150,10 @@ open class MangaDex : HttpSource() {
         return withIOContext {
             coroutineBinding {
                 val seasonal = async {
-                    fetchList(MdConstants.currentSeasonalId)
+                    fetchList(
+                            networkServices.service.getSeasonalList().mapSuccess { id }.getOrNull()
+                                ?: return@async null
+                        )
                         .andThen { listResults ->
                             Ok(
                                 listResults.copy(
@@ -232,7 +237,7 @@ open class MangaDex : HttpSource() {
                         .bind()
                 }
 
-                listOf(
+                listOfNotNull(
                     popularNewTitles.await(),
                     latestChapter.await(),
                     seasonal.await(),

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/SeasonalDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/models/dto/SeasonalDto.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.source.online.models.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class SeasonalDto(val id: String)

--- a/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
+++ b/constants/src/main/kotlin/org/nekomanga/constants/MdConstants.kt
@@ -6,7 +6,7 @@ import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 
 object MdConstants {
-    const val currentSeasonalId = "68ab4f4e-6f01-4898-9038-c5eee066be27"
+    const val seasonalApi = "https://antsylich.github.io/mangadex-seasonal/seasonal-list.min.json"
     const val staffPicksId = "805ba886-dd99-4aa4-b460-4bd7c7b71352"
     const val nekoDevPicksId = "4dd69b87-046e-4a85-9dca-ec88d7d314c7"
     const val name = "MangaDex"


### PR DESCRIPTION
Ideally, fork https://github.com/AntsyLich/mangadex-seasonal, remove the `manga_ids` field and only expose `id` in the `as_dict` function.