### PR TITLE
feat: only filter if all groups are filtered

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
@@ -165,7 +165,7 @@ class Suwayomi : MergedServerSource() {
         val separator = if (mangaUrl.contains(Constants.SEPARATOR)) Constants.SEPARATOR else " "
         val parts = mangaUrl.split(separator, limit = 3)
         val mangaId = parts[0]
-        val sourceName = parts.getOrNull(1)
+        val sourceName = parts.getOrElse(1, { "placeholder" })
         val lang = parts.getOrNull(2)?.let { fromSuwayomiLang(it) }
 
         return withContext(Dispatchers.IO) {
@@ -216,8 +216,9 @@ class Suwayomi : MergedServerSource() {
                                     "/manga/${mangaId}/chapter/${chapter.sourceOrder}" +
                                         " " +
                                         "${chapter.id}"
+                                val scanlators = chapter.scanlator?.split(", ") ?: emptyList()
                                 scanlator =
-                                    listOfNotNull(this@Suwayomi.name, sourceName, chapter.scanlator)
+                                    (listOf(this@Suwayomi.name, sourceName) + scanlators)
                                         .joinToString(Constants.SCANLATOR_SEPARATOR)
                                 language = lang
                                 date_upload = chapter.uploadDate

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterItemFilter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterItemFilter.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.util.chapter
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.source.online.merged.suwayomi.Suwayomi
 import org.nekomanga.constants.MdConstants
 import org.nekomanga.domain.chapter.ChapterItem
 import org.nekomanga.domain.details.MangaDetailsPreferences
@@ -121,12 +122,27 @@ class ChapterItemFilter(
                     language in filteredLanguagesList
                 }
 
-            val groupNotFound =
+            val groupNotBlocked =
                 ChapterUtil.getScanlators(chapterItem.chapter.scanlator).none { group ->
-                    group in blockedGroupList || group in filteredGroupList
+                    group in blockedGroupList
                 }
 
-            sourceFilter && languageNotFound && groupNotFound
+            // Filter only if the merge source is filtered or all of the chapter groups are filtered
+            val groupNotFiltered =
+                if (chapterItem.chapter.isMergedChapter()) {
+                    val scanlators =
+                        ChapterUtil.getScanlators(chapterItem.chapter.scanlator).toMutableList()
+                    val first = scanlators.removeAt(0)
+                    first !in filteredGroupList &&
+                        !(first == Suwayomi.name && scanlators.removeAt(0) in filteredGroupList) &&
+                        scanlators.any { group -> group !in filteredGroupList }
+                } else {
+                    ChapterUtil.getScanlators(chapterItem.chapter.scanlator).any { group ->
+                        group !in filteredGroupList
+                    }
+                }
+
+            sourceFilter && languageNotFound && groupNotBlocked && groupNotFiltered
         }
     }
 }


### PR DESCRIPTION
Merge source filters are kept, with Suwayomi as a special case (second on the list is the extension source name).

If a chapter has multiple groups and at least one is not filtered, it still shows. See #1898.