### PR TITLE
fix: suwayomi edge cases

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
@@ -171,8 +171,8 @@ class Suwayomi : MergedServerSource() {
         var sourceName = parts.getOrElse(1) { "placeholder" }
         sourceName =
             when (sourceName) {
-                // Add backspace so that it doesn't match in filteredBySource()
-                in SourceManager.mergeSourceNames -> sourceName + "\b"
+                // Add zero-width space so that it doesn't match in filteredBySource()
+                in SourceManager.mergeSourceNames -> sourceName + '\u200B'
                 else -> sourceName
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/Suwayomi.kt
@@ -131,7 +131,8 @@ class Suwayomi : MergedServerSource() {
 
         return responseBody.use { body ->
             with(json.decodeFromString<SuwayomiGraphQLDto<SuwayomiSearchMangaDto>>(body.string())) {
-                data.mangas.nodes.map { manga ->
+                data.mangas.nodes.mapNotNull { manga ->
+                    manga.source ?: return@mapNotNull null
                     SManga.create().apply {
                         this.title = manga.title
                         this.url =

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/SuwayomiDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/SuwayomiDto.kt
@@ -13,7 +13,7 @@ data class SuwayomiSeriesDto(
     val id: Long,
     val title: String,
     val thumbnailUrl: String,
-    val source: SuwayomiSourceDto,
+    val source: SuwayomiSourceDto?,
 )
 
 @Serializable data class SuwayomiSourceDto(val name: String, val lang: String)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/SuwayomiLang.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/merged/suwayomi/SuwayomiLang.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.source.online.merged.suwayomi
 
 enum class SuwayomiLang(val suwayomi: String, val mangadex: String) {
     ALL("all", ""),
+    LOCAL("localsourcelang", ""),
     CHINESE_SIMPLIFIED("zh-Hans", "zh"),
     CHINESE_TRADITIONAL("zh-Hant", "zh-hk"),
     FILIPINO("fil", "tl"),


### PR DESCRIPTION
- Non-installed sources
- Local source
- Some vendors render the backspace `\b` character, attempt to use zero-width space `\u200B` instead