### PR TITLE
fix: avoid ANR in chapter preload

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -408,7 +408,9 @@ class ReaderViewModel(
     private suspend fun preload(chapter: ReaderChapter) {
         if (chapter.pageLoader is HttpPageLoader) {
             val manga = manga ?: return
-            val isDownloaded = downloadManager.isChapterDownloaded(chapter.chapter, manga)
+            val isDownloaded = withIOContext {
+                downloadManager.isChapterDownloaded(chapter.chapter, manga)
+            }
             if (isDownloaded) {
                 chapter.state = ReaderChapter.State.Wait
             }


### PR DESCRIPTION
UI thread was being blocked by `listFiles()`. Offload it to the IO dispatcher.