### PR TITLE
fix: remove deleted merged chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -172,6 +172,7 @@ fun syncChaptersWithSource(
     dbChapters = db.getChapters(manga).executeAsBlocking()
 
     val dbChaptersByUrl = dbChapters.associateBy { it.url }
+    val sourceChaptersByUrl = sourceChapters.associateBy { it.url }
 
     // Chapters from the source not in db.
     val toAdd = mutableListOf<Chapter>()
@@ -239,9 +240,7 @@ fun syncChaptersWithSource(
             } else if (dbChapter.isLocalSource()) {
                 downloadManager.isChapterDownloaded(dbChapter, manga, true)
             } else {
-                sourceChapters.any { sourceChapter ->
-                    dbChapter.mangadex_chapter_id == sourceChapter.mangadex_chapter_id
-                }
+                sourceChaptersByUrl[dbChapter.url] != null
             }
         }
 


### PR DESCRIPTION
It currently only removes the ones that where deleted from MD, it should also do it for merged chapters