### PR TITLE
fix: add wildcards to search on the `FeedRepository` queries

### DIFF
--- a/app/src/main/java/org/nekomanga/data/database/repository/ChapterRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/ChapterRepositoryImpl.kt
@@ -84,7 +84,7 @@ class ChapterRepositoryImpl(
         sortByFetched: Boolean,
     ): Flow<List<LegacyMangaChapter>> {
         val sortByFetchedInt = if (sortByFetched) 1 else 0
-        return chapterDao.observeRecentChapters(search, limit, offset, sortByFetchedInt).map {
+        return chapterDao.observeRecentChapters("%$search%", limit, offset, sortByFetchedInt).map {
             it.map { LegacyMangaChapter(it.manga.toManga(), it.chapter.toChapter()) }
         }
     }
@@ -96,7 +96,7 @@ class ChapterRepositoryImpl(
         sortByFetched: Boolean,
     ): List<LegacyMangaChapter> {
         val sortByFetchedInt = if (sortByFetched) 1 else 0
-        return chapterDao.getRecentChapters(search, limit, offset, sortByFetchedInt).map {
+        return chapterDao.getRecentChapters("%$search%", limit, offset, sortByFetchedInt).map {
             LegacyMangaChapter(it.manga.toManga(), it.chapter.toChapter())
         }
     }

--- a/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/org/nekomanga/data/database/repository/HistoryRepositoryImpl.kt
@@ -20,7 +20,7 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
         limit: Int,
         offset: Int,
     ): Flow<List<LegacyMangaChapterHistory>> {
-        return historyDao.observeRecentHistoryUngrouped(search, limit, offset).map {
+        return historyDao.observeRecentHistoryUngrouped("%$search%", limit, offset).map {
             it.map {
                 LegacyMangaChapterHistory(
                     it.manga.toManga(),
@@ -36,7 +36,7 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
         limit: Int,
         offset: Int,
     ): List<LegacyMangaChapterHistory> {
-        return historyDao.getRecentHistoryUngrouped(search, limit, offset).map {
+        return historyDao.getRecentHistoryUngrouped("%$search%", limit, offset).map {
             LegacyMangaChapterHistory(
                 it.manga.toManga(),
                 it.chapter.toChapter(),
@@ -50,7 +50,7 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
         limit: Int,
         offset: Int,
     ): Flow<List<LegacyMangaChapterHistory>> {
-        return historyDao.observeRecentMangaLimit(search, limit, offset).map {
+        return historyDao.observeRecentMangaLimit("%$search%", limit, offset).map {
             it.map {
                 LegacyMangaChapterHistory(
                     it.manga.toManga(),
@@ -66,7 +66,7 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
         limit: Int,
         offset: Int,
     ): List<LegacyMangaChapterHistory> {
-        return historyDao.getRecentMangaLimit(search, limit, offset).map {
+        return historyDao.getRecentMangaLimit("%$search%", limit, offset).map {
             LegacyMangaChapterHistory(
                 it.manga.toManga(),
                 it.chapter.toChapter(),
@@ -88,7 +88,7 @@ class HistoryRepositoryImpl(private val historyDao: HistoryDao) : HistoryReposit
         limit: Int,
         offset: Int,
     ): Flow<List<MangaChapterHistory>> {
-        return historyDao.observeAllRecentsTypes(search, includeRead, limit, offset)
+        return historyDao.observeAllRecentsTypes("%$search%", includeRead, limit, offset)
     }
 
     override fun observeChapterHistoryByMangaId(


### PR DESCRIPTION
They were missing in the `StorIO -> Room` migration