### PR TITLE
feat: tall image splitting on reader

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -529,7 +529,7 @@ class Downloader(
     }
 
     private fun splitTallImageIfNeeded(page: Page, tmpDir: UniFile) {
-        if (!readerPreferences.splitTallImages().get()) return
+        if (!readerPreferences.splitTallImagesDownload().get()) return
 
         try {
             val fileName = "%03d".format(Locale.ENGLISH, page.number)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/model/ReaderPage.kt
@@ -50,3 +50,11 @@ open class ReaderPage(
     fun isFromSamePage(page: ReaderPage): Boolean =
         index == page.index && chapter.chapter.id == page.chapter.chapter.id
 }
+
+data class ReaderPageSplit(
+    val page: ReaderPage,
+    val topOffset: Int,
+    val splitHeight: Int,
+    var cachedBytes: ByteArray? = null,
+    var displayedHeight: Int = 0,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
@@ -84,6 +84,7 @@ class ReaderPagedView @JvmOverloads constructor(context: Context, attrs: Attribu
             webtoonPageTransitions.bindToPreference(
                 readerPreferences.animatedPageTransitionsWebtoon()
             )
+            webtoonSplitTallImages.bindToPreference(readerPreferences.splitTallImagesReader())
 
             updatePagedGroup(!isWebtoonView)
         }
@@ -123,6 +124,7 @@ class ReaderPagedView @JvmOverloads constructor(context: Context, attrs: Attribu
                 binding.webtoonPageLayout,
                 binding.webtoonInvertDoublePages,
                 binding.webtoonPageTransitions,
+                binding.webtoonSplitTallImages,
             )
             .forEach { it.isVisible = !show }
         val isFullFit =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPageSplit
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.hasMissingChapters
@@ -20,11 +21,15 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
     var currentChapter: ReaderChapter? = null
 
+    /** Tracks which pages have already been tall-split to prevent re-splitting on rebind. */
+    val tallSplitPages = mutableSetOf<ReaderPage>()
+
     /**
      * Updates this adapter with the given [chapters]. It handles setting a few pages of the
      * next/previous chapter to allow seamless transitions.
      */
     fun setChapters(chapters: ViewerChapters, forceTransition: Boolean) {
+        tallSplitPages.clear()
         val newItems = mutableListOf<Any>()
 
         // Force chapter transition page if there are missing chapters
@@ -93,6 +98,21 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
         result.dispatchUpdatesTo(this)
     }
 
+    /**
+     * Inserts [insertPages] after [originalPage] in the items list. Called when a tall page is
+     * split into multiple chunks.
+     */
+    fun notifyPageSplit(originalPage: ReaderPage, insertPages: List<ReaderPageSplit>) {
+        tallSplitPages.add(originalPage)
+        val position = items.indexOf(originalPage)
+        if (position < 0) return
+        val newItems = items.toMutableList()
+        newItems.addAll(position + 1, insertPages)
+        val result = DiffUtil.calculateDiff(Callback(items, newItems))
+        items = newItems
+        result.dispatchUpdatesTo(this)
+    }
+
     /** Returns the amount of items of the adapter. */
     override fun getItemCount(): Int {
         return items.size
@@ -102,6 +122,7 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
     override fun getItemViewType(position: Int): Int {
         return when (val item = items[position]) {
             is ReaderPage -> PAGE_VIEW
+            is ReaderPageSplit -> SPLIT_PAGE_VIEW
             is ChapterTransition -> TRANSITION_VIEW
             else -> error("Unknown view type for ${item.javaClass}")
         }
@@ -110,7 +131,8 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
     /** Creates a new view holder for an item with the given [viewType]. */
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
-            PAGE_VIEW -> {
+            PAGE_VIEW,
+            SPLIT_PAGE_VIEW -> {
                 val view = ReaderPageImageView(parent.context, isWebtoon = true)
                 WebtoonPageHolder(view, viewer)
             }
@@ -126,7 +148,7 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val item = items[position]
         when (holder) {
-            is WebtoonPageHolder -> holder.bind(item as ReaderPage)
+            is WebtoonPageHolder -> holder.bind(item)
             is WebtoonTransitionHolder -> holder.bind(item as ChapterTransition)
         }
     }
@@ -173,5 +195,8 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
 
         /** View holder type of a chapter transition view. */
         const val TRANSITION_VIEW = 1
+
+        /** View holder type of a tall page split chunk. */
+        const val SPLIT_PAGE_VIEW = 2
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -47,6 +47,8 @@ class WebtoonConfig(
     var splitPages =
         readerPreferences.webtoonPageLayout().get() == PageLayout.SPLIT_PAGES.webtoonValue
 
+    var splitTallPages = readerPreferences.splitTallImagesReader().get()
+
     var invertDoublePages = false
 
     var menuThreshold = PreferenceValues.ReaderHideThreshold.LOW.threshold
@@ -98,6 +100,13 @@ class WebtoonConfig(
                 { splitPages = it == PageLayout.SPLIT_PAGES.webtoonValue },
                 { imagePropertyChangedListener?.invoke() },
             )
+        readerPreferences.splitTallImagesReader().apply {
+            register({ splitTallPages = it })
+            changes()
+                .drop(1)
+                .onEach { reloadViewerListener?.invoke() }
+                .launchIn(scope)
+        }
         readerPreferences.webtoonReaderHideThreshold().register({ menuThreshold = it.threshold })
         readerPreferences
             .webtoonInvertDoublePages()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -3,7 +3,12 @@ package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.BitmapRegionDecoder
 import android.graphics.Color
+import android.graphics.Rect
+import android.os.Build
 import android.view.Gravity
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -18,6 +23,7 @@ import androidx.core.view.updatePaddingRelative
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPageSplit
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressBar
 import eu.kanade.tachiyomi.util.system.ImageUtil
@@ -29,6 +35,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.Buffer
 import okio.BufferedSource
 import okio.buffer
 import okio.source
@@ -66,6 +73,10 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
     /** Page of a chapter. */
     private var page: ReaderPage? = null
 
+    private var regionTop = 0
+    private var regionHeight = 0
+    private var splitPage: ReaderPageSplit? = null
+
     private val scope = MainScope()
 
     /** Job for loading the page. */
@@ -92,9 +103,24 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
         frame.onScaleChanged = { viewer.activity.hideMenu() }
     }
 
-    /** Binds the given [page] with this view holder, subscribing to its state. */
-    fun bind(page: ReaderPage) {
-        this.page = page
+    fun bind(item: Any) {
+        when (item) {
+            is ReaderPage -> {
+                page = item
+                regionTop = 0
+                regionHeight = 0
+                splitPage = null
+            }
+            is ReaderPageSplit -> {
+                page = item.page
+                regionTop = item.topOffset
+                regionHeight = item.splitHeight
+                splitPage = item
+                if (item.displayedHeight > 0) {
+                    progressContainer.layoutParams?.height = item.displayedHeight
+                }
+            }
+        }
         launchLoadJob()
         refreshLayoutParams()
     }
@@ -118,6 +144,9 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
         cancelLoadJob()
         cancelProgressJob()
         unsubscribeReadImageHeader()
+
+        regionTop = 0
+        regionHeight = 0
 
         removeDecodeErrorLayout()
         frame.recycle()
@@ -268,14 +297,109 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
             }
     }
 
-    private fun process(imageStream: BufferedSource): BufferedSource {
+    private suspend fun checkTallImage(stream: BufferedSource): BufferedSource {
+        if (!viewer.config.splitTallPages || regionHeight > 0 || page == null) {
+            return stream
+        }
+
+        val imageBytes = stream.readByteArray()
+
+        if (viewer.adapter.tallSplitPages.contains(page)) {
+            val firstSplit =
+                viewer.adapter.items
+                    .filterIsInstance<ReaderPageSplit>()
+                    .firstOrNull { it.page == page }
+            if (firstSplit != null) {
+                regionTop = 0
+                regionHeight = firstSplit.topOffset
+                return decodeRegion(imageBytes, 0, regionHeight)
+            }
+            return Buffer().write(imageBytes)
+        }
+
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size, options)
+        if (options.outHeight <= 0 || options.outWidth <= 0) {
+            return Buffer().write(imageBytes)
+        }
+
+        if (options.outHeight / options.outWidth <= 3) {
+            return Buffer().write(imageBytes)
+        }
+
+        val screenHeight = Resources.getSystem().displayMetrics.heightPixels
+        val displayMaxHeight = maxOf(viewer.recycler.height, screenHeight) * 2
+        if (options.outHeight <= displayMaxHeight) {
+            return Buffer().write(imageBytes)
+        }
+
+        val partCount = (options.outHeight - 1) / displayMaxHeight + 1
+        val optimalSplitHeight = options.outHeight / partCount
+
+        val insertPages = mutableListOf<ReaderPageSplit>()
+        for (i in 1 until partCount) {
+            val topOffset = i * optimalSplitHeight
+            val splitH = minOf(optimalSplitHeight, options.outHeight - topOffset)
+            insertPages.add(ReaderPageSplit(page!!, topOffset, splitH))
+        }
+
+        if (insertPages.isNotEmpty()) {
+            withContext(Dispatchers.Main) { viewer.adapter.notifyPageSplit(page!!, insertPages) }
+            regionTop = 0
+            regionHeight = optimalSplitHeight
+        }
+
+        return decodeRegion(imageBytes, 0, optimalSplitHeight)
+    }
+
+    private fun decodeRegion(
+        imageBytes: ByteArray,
+        top: Int,
+        height: Int,
+    ): BufferedSource {
+        val decoder =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                BitmapRegionDecoder.newInstance(imageBytes, 0, imageBytes.size)
+            } else {
+                @Suppress("DEPRECATION")
+                BitmapRegionDecoder.newInstance(imageBytes, 0, imageBytes.size, false)
+            }
+
+        val region = Rect(0, top, decoder.width, top + height)
+        val bitmap =
+            decoder.decodeRegion(
+                region,
+                BitmapFactory.Options().apply { inPreferredConfig = Bitmap.Config.RGB_565 },
+            )
+        decoder.recycle()
+
+        bitmap ?: return Buffer().write(imageBytes)
+
+        return Buffer().write(ImageUtil.bitmapToBytes(bitmap))
+    }
+
+    private suspend fun process(imageStream: BufferedSource): BufferedSource {
+        if (regionHeight > 0) {
+            val split = splitPage
+            if (split?.cachedBytes != null) {
+                return Buffer().write(split.cachedBytes!!)
+            }
+            val imageBytes = imageStream.readByteArray()
+            val result = decodeRegion(imageBytes, regionTop, regionHeight)
+            if (split != null) {
+                split.cachedBytes = result.readByteArray()
+                return Buffer().write(split.cachedBytes!!)
+            }
+            return result
+        }
+
         if (!viewer.config.splitPages) {
-            return imageStream
+            return checkTallImage(imageStream)
         }
 
         val isDoublePage = ImageUtil.isWideImage(imageStream)
         if (!isDoublePage) {
-            return imageStream
+            return checkTallImage(imageStream)
         }
 
         return ImageUtil.splitAndStackBitmap(
@@ -294,7 +418,9 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
     /** Called when the image is decoded and going to be displayed. */
     private fun onImageDecoded() {
         progressContainer.isVisible = false
-        page?.renderedHeight = frame.measuredHeight
+        val h = frame.measuredHeight
+        page?.renderedHeight = h
+        splitPage?.displayedHeight = h
     }
 
     /** Called when the image fails to decode. */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -28,6 +28,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressBar
 import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.dpToPx
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
@@ -147,6 +148,7 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
 
         regionTop = 0
         regionHeight = 0
+        splitPage = null
 
         removeDecodeErrorLayout()
         frame.recycle()
@@ -291,6 +293,7 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
                     awaitCancellation()
                 } catch (e: Exception) {
                     org.nekomanga.logging.TimberKt.e(e) { "Error loading webtoon page" }
+                    if (e is CancellationException) throw e
                 } finally {
                     runCatching { openStream?.close() }
                 }
@@ -375,7 +378,9 @@ class WebtoonPageHolder(private val frame: ReaderPageImageView, viewer: WebtoonV
 
         bitmap ?: return Buffer().write(imageBytes)
 
-        return Buffer().write(ImageUtil.bitmapToBytes(bitmap))
+        return Buffer().apply {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream())
+        }
     }
 
     private suspend fun process(imageStream: BufferedSource): BufferedSource {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -60,7 +60,7 @@ class WebtoonViewer(val activity: ReaderActivity, val noWebtoonTag: Boolean = fa
     private val layoutManager = WebtoonLayoutManager(activity)
 
     /** Adapter of the recycler view. */
-    private val adapter = WebtoonAdapter(this)
+    val adapter = WebtoonAdapter(this)
 
     /** Distance to scroll when the user taps on one side of the recycler view. */
     private var scrollDistance = activity.resources.displayMetrics.heightPixels * 3 / 4

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -491,12 +491,6 @@ object ImageUtil {
         return options.outWidth > options.outHeight
     }
 
-    fun bitmapToBytes(bitmap: Bitmap): ByteArray {
-        val output = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output)
-        return output.toByteArray()
-    }
-
     fun splitAndStackBitmap(
         imageStream: InputStream,
         rightSideOnTop: Boolean,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ImageUtil.kt
@@ -491,6 +491,12 @@ object ImageUtil {
         return options.outWidth > options.outHeight
     }
 
+    fun bitmapToBytes(bitmap: Bitmap): ByteArray {
+        val output = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 90, output)
+        return output.toByteArray()
+    }
+
     fun splitAndStackBitmap(
         imageStream: InputStream,
         rightSideOnTop: Boolean,
@@ -940,7 +946,7 @@ object ImageUtil {
         return options
     }
 
-    private fun extractImageOptions(imageSource: BufferedSource): BitmapFactory.Options {
+    fun extractImageOptions(imageSource: BufferedSource): BitmapFactory.Options {
         val imageBytes = imageSource.peek().readByteArray()
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size, options)

--- a/app/src/main/java/org/nekomanga/domain/reader/ReaderPreferences.kt
+++ b/app/src/main/java/org/nekomanga/domain/reader/ReaderPreferences.kt
@@ -131,7 +131,15 @@ class ReaderPreferences(private val preferenceStore: PreferenceStore) {
 
     fun preloadPageAmount() = this.preferenceStore.getInt("preload_size", 6)
 
-    fun splitTallImages() = this.preferenceStore.getBoolean("split_tall_images")
+    fun splitTallImagesDownload() = this.preferenceStore.getBoolean(
+        "split_tall_images_download",
+        this.preferenceStore.getBoolean("split_tall_images").get(),
+    )
+
+    fun splitTallImagesReader() = this.preferenceStore.getBoolean(
+        "split_tall_images_reader",
+        this.preferenceStore.getBoolean("split_tall_images").get(),
+    )
 
     fun doublePageRotate() = this.preferenceStore.getBoolean("double_page_rotate")
 

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
@@ -41,9 +41,9 @@ internal class DownloadSettingsScreen(
                 title = stringResource(R.string.save_chapters_as_cbz),
             ),
             Preference.PreferenceItem.SwitchPreference(
-                pref = readerPreferences.splitTallImages(),
-                title = stringResource(R.string.split_tall_images),
-                subtitle = stringResource(R.string.split_tall_images_summary),
+                pref = readerPreferences.splitTallImagesDownload(),
+                title = stringResource(R.string.split_tall_images_download),
+                subtitle = stringResource(R.string.split_tall_images_download_summary),
             ),
             removeAfterReadGroup(),
             downloadNewChaptersGroup(),
@@ -193,7 +193,11 @@ internal class DownloadSettingsScreen(
             return persistentListOf(
                 SearchTerm(title = stringResource(R.string.only_download_over_unmetered)),
                 SearchTerm(title = stringResource(R.string.save_chapters_as_cbz)),
-                SearchTerm(title = stringResource(R.string.split_tall_images_summary)),
+                SearchTerm(
+                    title = stringResource(R.string.split_tall_images_download),
+                    subtitle = stringResource(R.string.split_tall_images_download_summary),
+                    group = stringResource(R.string.split_tall_images_download)
+                ),
                 SearchTerm(
                     title = stringResource(R.string.remove_when_marked_as_read),
                     group = stringResource(R.string.remove_after_read),

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/DownloadSettingsScreen.kt
@@ -43,7 +43,7 @@ internal class DownloadSettingsScreen(
             Preference.PreferenceItem.SwitchPreference(
                 pref = readerPreferences.splitTallImagesDownload(),
                 title = stringResource(R.string.split_tall_images_download),
-                subtitle = stringResource(R.string.split_tall_images_download_summary),
+                subtitle = stringResource(R.string.split_tall_images_summary),
             ),
             removeAfterReadGroup(),
             downloadNewChaptersGroup(),
@@ -195,7 +195,7 @@ internal class DownloadSettingsScreen(
                 SearchTerm(title = stringResource(R.string.save_chapters_as_cbz)),
                 SearchTerm(
                     title = stringResource(R.string.split_tall_images_download),
-                    subtitle = stringResource(R.string.split_tall_images_download_summary),
+                    subtitle = stringResource(R.string.split_tall_images_summary),
                     group = stringResource(R.string.split_tall_images_download)
                 ),
                 SearchTerm(

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
@@ -434,6 +434,11 @@ internal class ReaderSettingsScreen(
                                 .toPersistentMap(),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
+                        pref = readerPreferences.splitTallImagesReader(),
+                        title = stringResource(R.string.split_tall_images_reader),
+                        subtitle = stringResource(R.string.split_tall_images_reader_summary),
+                    ),
+                    Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.webtoonInvertDoublePages(),
                         title = stringResource(R.string.invert_double_pages),
                     ),
@@ -646,6 +651,11 @@ internal class ReaderSettingsScreen(
                 ),
                 SearchTerm(
                     title = stringResource(R.string.page_layout),
+                    group = stringResource(R.string.webtoon),
+                ),
+                SearchTerm(
+                    title = stringResource(R.string.split_tall_images_reader),
+                    subtitle = stringResource(R.string.split_tall_images_reader_summary),
                     group = stringResource(R.string.webtoon),
                 ),
                 SearchTerm(

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/ReaderSettingsScreen.kt
@@ -436,7 +436,7 @@ internal class ReaderSettingsScreen(
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.splitTallImagesReader(),
                         title = stringResource(R.string.split_tall_images_reader),
-                        subtitle = stringResource(R.string.split_tall_images_reader_summary),
+                        subtitle = stringResource(R.string.split_tall_images_summary),
                     ),
                     Preference.PreferenceItem.SwitchPreference(
                         pref = readerPreferences.webtoonInvertDoublePages(),
@@ -655,7 +655,7 @@ internal class ReaderSettingsScreen(
                 ),
                 SearchTerm(
                     title = stringResource(R.string.split_tall_images_reader),
-                    subtitle = stringResource(R.string.split_tall_images_reader_summary),
+                    subtitle = stringResource(R.string.split_tall_images_summary),
                     group = stringResource(R.string.webtoon),
                 ),
                 SearchTerm(

--- a/app/src/main/res/layout/reader_paged_layout.xml
+++ b/app/src/main/res/layout/reader_paged_layout.xml
@@ -194,5 +194,13 @@
             android:layout_marginTop="16dp"
             android:text="@string/invert_double_pages"
             android:textColor="?attr/colorOnBackground" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/webtoon_split_tall_images"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/split_tall_images_reader"
+            android:textColor="?attr/colorOnBackground" />
     </LinearLayout>
 </eu.kanade.tachiyomi.ui.reader.settings.ReaderPagedView>

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -1129,8 +1129,10 @@
     <string name="always_delete">Always delete</string>
     <string name="automatic_removal">Automatic removal</string>
     <string name="save_chapters_as_cbz">Save as CBZ archive</string>
-    <string name="split_tall_images">Split tall images</string>
-    <string name="split_tall_images_summary">Improves reader performance</string>
+    <string name="split_tall_images_reader">Split tall images</string>
+    <string name="split_tall_images_reader_summary">Improves webtoon reader performance</string>
+    <string name="split_tall_images_download">Split tall images while downloading</string>
+    <string name="split_tall_images_download_summary">Splits tall pages during download for better webtoon reader performance</string>
 
 
     <!-- Stats -->

--- a/constants/src/main/res/values/strings.xml
+++ b/constants/src/main/res/values/strings.xml
@@ -1130,9 +1130,8 @@
     <string name="automatic_removal">Automatic removal</string>
     <string name="save_chapters_as_cbz">Save as CBZ archive</string>
     <string name="split_tall_images_reader">Split tall images</string>
-    <string name="split_tall_images_reader_summary">Improves webtoon reader performance</string>
     <string name="split_tall_images_download">Split tall images while downloading</string>
-    <string name="split_tall_images_download_summary">Splits tall pages during download for better webtoon reader performance</string>
+    <string name="split_tall_images_summary">Improves webtoon reader performance</string>
 
 
     <!-- Stats -->


### PR DESCRIPTION
The old split setting key is applied to both, since they don't interfere with each other, and they serve the same reader performance purpose