### PR TITLE
fix: show user-selected title on download screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -238,7 +238,7 @@ fun LibraryManga.toLibraryMangaItem(): LibraryMangaItem {
 }
 
 fun Manga.toSimpleManga(): SimpleManga {
-    return SimpleManga(id = this.id!!, title = (this as? MangaImpl)?.title ?: this.title)
+    return SimpleManga(id = this.id!!, title = this.displayTitle())
 }
 
 fun SManga.getSlug(): String {


### PR DESCRIPTION
Just use the existing `Manga.displayTitle()` method