### PR TITLE
fix: multiple small reader issues

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1121,8 +1121,8 @@ class ReaderActivity : BaseMainActivity() {
     }
 
     private suspend fun loadChapter(chapter: ReaderChapter) {
-        val lastPage = viewModel.loadChapter(chapter) ?: return
-        launchUI { moveToPageIndex(lastPage, false, chapterChange = true) }
+        viewModel.loadChapter(chapter) ?: return
+        isScrollingThroughPagesOrChapters = false
         refreshChapters()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -358,7 +358,15 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
             when {
                 (oldCurrent?.first as? ReaderPage)?.chapter != currentChapter &&
                     (oldCurrent?.first as? ChapterTransition)?.from != currentChapter ->
-                    subItems.find { (it as? ReaderPage)?.chapter == currentChapter }
+                    if (oldCurrent?.first is ChapterTransition.Prev) {
+                        subItems
+                            .filterIsInstance<ReaderPage>()
+                            .filter { it.chapter == currentChapter }
+                            .maxByOrNull { it.index }
+                            ?: subItems.find { (it as? ReaderPage)?.chapter == currentChapter }
+                    } else {
+                        subItems.find { (it as? ReaderPage)?.chapter == currentChapter }
+                    }
                 useSecondPage && oldCurrent?.second is ReaderPage ->
                     (oldCurrent.second ?: oldCurrent.first)
                 else -> oldCurrent?.first ?: return

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
@@ -96,7 +96,7 @@ fun ComposeWebtoonViewer(
                 when (readerTheme) {
                     0 -> Color.White
                     1 -> Color.Black
-                    2 -> Color.White
+                    2 -> themeBackground
                     3 -> themeBackground
                     4 -> Color.Black
                     else -> themeBackground

--- a/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/reader/viewer/ComposeWebtoonViewer.kt
@@ -160,13 +160,13 @@ fun ComposeWebtoonViewer(
                             val itemMiddle = it.offset + it.size / 2
                             abs(itemMiddle - viewportMiddle)
                         } ?: visibleItems.first()
-                    activeItemInfo.index
+                    activeItemInfo.index to lazyListState.isScrollInProgress
                 } else {
-                    lazyListState.firstVisibleItemIndex
+                    lazyListState.firstVisibleItemIndex to lazyListState.isScrollInProgress
                 }
             }
-                .collect { activeIndex ->
-                    if (activeIndex in items.indices) {
+                .collect { (activeIndex, scrolling) ->
+                    if (!scrolling && activeIndex in items.indices) {
                         val item = items[activeIndex]
                         when (item) {
                             is ReaderUiItem.Page -> {


### PR DESCRIPTION
 - Make chapter transition background in `Smart (by page)` mode follow the theme.
 - Fix page jumping back to 1 instead of the last page when going back a chapter.
 - Supress the progress bar jitter when jumping to a page on the webtoon reader.