### PR TITLE
fix: prevent unlock prompt on reader exit and validate biometric toggle

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseMainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/activity/BaseMainActivity.kt
@@ -15,9 +15,4 @@ open class BaseMainActivity : AppCompatActivity() {
         super.onResume()
         SecureActivityDelegate.promptLockIfNeeded(this)
     }
-
-    override fun finish() {
-        super.finish()
-        SecureActivityDelegate.locked = true
-    }
 }

--- a/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SecuritySettingsScreen.kt
+++ b/app/src/main/java/org/nekomanga/presentation/screens/settings/screens/SecuritySettingsScreen.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.authenticate
 import eu.kanade.tachiyomi.util.system.AuthenticatorUtil.isAuthenticationSupported
 import eu.kanade.tachiyomi.util.system.getActivity
+import java.util.Date
 import org.nekomanga.R
 import org.nekomanga.core.security.SecurityPreferences
 import org.nekomanga.presentation.screens.settings.Preference
@@ -31,10 +32,16 @@ internal class SecuritySettingsScreen(
                 title = stringResource(R.string.lock_with_biometrics),
                 enabled = context.isAuthenticationSupported(),
                 onValueChanged = {
-                    (context as FragmentActivity).authenticate(
-                        title = context.getString(R.string.lock_with_biometrics)
-                    )
-                    true
+                    val activity = context.getActivity() as? FragmentActivity
+                    val authenticated =
+                        activity?.authenticate(
+                            title = context.getString(R.string.lock_with_biometrics)
+                        ) ?: false
+                    if (authenticated) {
+                        SecureActivityDelegate.locked = false
+                        securityPreferences.lastUnlock().set(Date().time)
+                    }
+                    authenticated
                 },
             ),
             Preference.PreferenceItem.ListPreference(
@@ -63,10 +70,11 @@ internal class SecuritySettingsScreen(
                     SecurityPreferences.SecureScreenMode.entries
                         .associate { it to stringResource(it.titleResId) }
                         .toMap(),
-                onValueChanged = {
+                onValueChanged = { newValue ->
+                    securityPreferences.secureScreen().set(newValue)
                     val activity = context.getActivity()
                     if (activity != null) {
-                        SecureActivityDelegate.setSecure(context.getActivity())
+                        SecureActivityDelegate.setSecure(activity)
                     }
                     true
                 },


### PR DESCRIPTION
### Summary of Changes
  
  1. Prevent unlock prompt when exiting a chapter (BaseMainActivity.kt:7-18): 
      • Removed the finish() override that set SecureActivityDelegate.kt:18. When ReaderActivity.kt:181 finishes, the app remains in the foreground, so it     
      should not be locked. Background app locking continues to be handled by App.kt:217-221 observing ProcessLifecycleOwner.                          
  2. Validate authentication on biometric toggle (SecuritySettingsScreen.kt:30-46):                                                            
      • Checked the return value of AuthenticatorUtil.kt:50-83 in onValueChanged. If authentication is cancelled or fails, it returns false, preventing the
      preference from being changed.
      • Updated SecureActivityDelegate.kt:18 and updated SecurityPreferences.kt:17 timestamp upon successful authentication.
      • Ensured SecureActivityDelegate.kt:20 receives the updated SecureScreenMode when changed in settings.