### PR TITLE
fix: sync title when returning to browse screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaExtensions.kt
@@ -299,6 +299,8 @@ suspend fun List<DisplayManga>.resyncDisplayManga(
             else ->
                 displayManga.copy(
                     inLibrary = dbManga.favorite,
+                    originalTitle = dbManga.title,
+                    userTitle = dbManga.user_title ?: "",
                     currentArtwork =
                         displayManga.currentArtwork.copy(
                             cover = dbManga.user_cover ?: "",


### PR DESCRIPTION
If you change the selected title and return to a browse screen it currently doesn't update